### PR TITLE
Add `repr(transparent)` to `NonAny*`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ macro_rules! nonany {
         #[doc = concat!("assert_eq!(core::mem::size_of::<Option<nonany::", stringify!($name), "<0>>>(), core::mem::size_of::<", stringify!($int), ">());")]
         /// ```
         #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+        #[repr(transparent)]
         pub struct $name<const NICHE: $int>(core::num::$nonzero);
 
         impl<const NICHE: $int> $name<NICHE> {


### PR DESCRIPTION
Add `repr(transparent)` to `NonAny*` to ensure that their layouts are the same as their inner `NonZero*`.
This guarantees that `Option<NonAny*>` have the same layout as `NonAny*`.
For more information, see <https://doc.rust-lang.org/std/option/index.html#representation>.